### PR TITLE
Blog post image feature

### DIFF
--- a/resources/contentful/getPostCollection.graphql
+++ b/resources/contentful/getPostCollection.graphql
@@ -19,6 +19,7 @@ query postCollectionQuery($type: [String]) {
       slug
       postImage{
         url
+        title
       }
       content {
         json

--- a/resources/contentful/getPostCollection.graphql
+++ b/resources/contentful/getPostCollection.graphql
@@ -17,6 +17,9 @@ query postCollectionQuery($type: [String]) {
       title
       publishDate
       slug
+      postImage{
+        url
+      }
       content {
         json
       }

--- a/resources/contentful/getPostList.graphql
+++ b/resources/contentful/getPostList.graphql
@@ -17,6 +17,9 @@ query postListQuery($type: [String]) {
       title
       publishDate
       slug
+      postImage{
+        url
+      }
       shortDescription {
         json
       }

--- a/resources/contentful/getPostList.graphql
+++ b/resources/contentful/getPostList.graphql
@@ -19,6 +19,7 @@ query postListQuery($type: [String]) {
       slug
       postImage{
         url
+        title
       }
       shortDescription {
         json

--- a/resources/contentful/getPostsByList.graphql
+++ b/resources/contentful/getPostsByList.graphql
@@ -9,6 +9,9 @@ query postsByListQuery($listId: String!, $limit: Int!) {
           type
           slug
           title
+          postImage{
+            url
+          }
           shortDescription {
             json
           }

--- a/resources/contentful/getPostsByList.graphql
+++ b/resources/contentful/getPostsByList.graphql
@@ -11,6 +11,7 @@ query postsByListQuery($listId: String!, $limit: Int!) {
           title
           postImage{
             url
+            title
           }
           shortDescription {
             json

--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1606,10 +1606,6 @@ body .content .card-list ul {
   }
 }
 
-.post-list .post a.action {
-  align-self:flex-end
-}
-
 .post-list .post .image {
   grid-column: span 4 / span 4;
   display: none;
@@ -1638,7 +1634,6 @@ body .content .card-list ul {
 
 .post-list .post .post-body {
   margin-bottom: 0.75rem;
-  width: 90%;
 }
 
 .post-list .post h2 {
@@ -1867,12 +1862,6 @@ body.post-page code {
   --tw-shadow: var(--tw-shadow-colored);
   box-shadow: inset 1px 1px 3px;
   overflow-wrap: break-word;
-}
-
-body.post-page img {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-  display: none;
 }
 
 @media (min-width: 640px) {

--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1553,10 +1553,9 @@ body .content .card-list ul {
 }
 
 .post-list .post {
-  margin-left: 4rem;
-  margin-right: 4rem;
   margin-bottom: 4rem;
   display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
   gap: 2.5rem;
   vertical-align: text-bottom;
 }
@@ -1589,29 +1588,52 @@ body .content .card-list ul {
   }
 }
 
-.post-list .post {
-  grid-template-columns: 40% 60%;
-  width: 80vw;
+@media (min-width: 768px) {
+  .post-list .post {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
 }
 
 .post-list .post a.action {
+  float: left;
   margin-top: auto;
   align-self: flex-start;
-  align-self:flex-end;
+}
+
+@media (min-width: 768px) {
+  .post-list .post a.action {
+    float: right;
+  }
+}
+
+.post-list .post a.action {
+  align-self:flex-end
 }
 
 .post-list .post .image {
-  grid-column: span 1 / span 1;
+  grid-column: span 4 / span 4;
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .post-list .post .image {
+    display: block;
+  }
+}
+
+.post-list .post .image {
   max-height: 40vh;
 }
 
 .post-list .post .image img {
-  --tw-grayscale: grayscale(100%);
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
   height: 100%;
   width: 100%;
   -o-object-fit: cover;
      object-fit: cover;
+}
+
+.post-list .post .body {
+  grid-column: span 6 / span 6;
 }
 
 .post-list .post .post-body {

--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1553,9 +1553,11 @@ body .content .card-list ul {
 }
 
 .post-list .post {
+  margin-left: 4rem;
+  margin-right: 4rem;
   margin-bottom: 4rem;
   display: grid;
-  gap: 1rem;
+  gap: 2.5rem;
   vertical-align: text-bottom;
 }
 
@@ -1589,11 +1591,13 @@ body .content .card-list ul {
 
 .post-list .post {
   grid-template-columns: 40% 60%;
+  width: 80vw;
 }
 
 .post-list .post a.action {
   margin-top: auto;
   align-self: flex-start;
+  align-self:flex-end;
 }
 
 .post-list .post .image {
@@ -1610,6 +1614,7 @@ body .content .card-list ul {
 
 .post-list .post .post-body {
   margin-bottom: 0.75rem;
+  width: 90%;
 }
 
 .post-list .post h2 {

--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1522,8 +1522,6 @@ body .content .card-list ul {
 
 .post-list {
   display: grid;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-  gap: 2rem;
 }
 
 .services .content .side-by-side .embed .post-list {
@@ -1554,28 +1552,60 @@ body .content .card-list ul {
   }
 }
 
-@media (min-width: 640px) {
-  .post-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+.post-list .post {
+  margin-bottom: 4rem;
+  display: grid;
+  gap: 1rem;
+  vertical-align: text-bottom;
+}
+
+.services .content .side-by-side .embed .post-list .post {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+@media (min-width: 768px) {
+  .services .content .side-by-side .embed .post-list .post {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }
 
 @media (min-width: 1024px) {
-  .post-list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .services .content .side-by-side .embed .post-list .post {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .services .content .side-by-side .embed .post-list .post {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1536px) {
+  .services .content .side-by-side .embed .post-list .post {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
   }
 }
 
 .post-list .post {
-  margin-bottom: 4rem;
-  display: flex;
-  flex-direction: column;
-  vertical-align: text-bottom;
+  grid-template-columns: 40% 60%;
 }
 
 .post-list .post a.action {
   margin-top: auto;
   align-self: flex-start;
+}
+
+.post-list .post .image {
+  grid-column: span 1 / span 1;
+  max-height: 40vh;
+}
+
+.post-list .post .image img {
+  height: 100%;
+  width: 100%;
+  -o-object-fit: cover;
+     object-fit: cover;
 }
 
 .post-list .post .post-body {
@@ -1813,6 +1843,7 @@ body.post-page code {
 body.post-page img {
   margin-top: 2rem;
   margin-bottom: 2rem;
+  display: none;
 }
 
 @media (min-width: 640px) {

--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1606,6 +1606,8 @@ body .content .card-list ul {
 }
 
 .post-list .post .image img {
+  --tw-grayscale: grayscale(100%);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
   height: 100%;
   width: 100%;
   -o-object-fit: cover;

--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1845,9 +1845,7 @@ body.post-page .post-body {
   text-align: left;
 }
 
-body.post-page img {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
+body.post-page .image {
   display: none;
 }
 

--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1845,6 +1845,12 @@ body.post-page .post-body {
   text-align: left;
 }
 
+body.post-page img {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  display: none;
+}
+
 body.post-page code {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;

--- a/src/generator/contentful.clj
+++ b/src/generator/contentful.clj
@@ -69,11 +69,7 @@
 (comment (get-contentful :asset-query {:$assetId "34YRcoaS4WJ5ORhpMlMHRM"}))
 (comment (get-contentful :entry-query {:entryId "782ka3lNsGXBrnE88Qf3jt"}))
 (comment (get-contentful :card-list-query {:listId "2pJ63nhY2QKbVesxgWOvq9"}))
-(comment 
-  
-  (get-contentful :post-collection-query {:type ["news" "dev" "article"]})
-  
-  )
+(comment (get-contentful :post-collection-query {:type ["news" "dev" "article"]}))
 (comment (json/write-str (:graphql ((get-in query-map [:query :asset-query]) {:assetId "34YRcoaS4WJ5ORhpMlMHRM"}))))
 (comment (:variables (:graphql ((get-in query-map [:query :nav-collection-query]) {:name "Main menu"}))))
 (comment (memo/memo-clear! api-call)) ; evaluate this in REPL to clear memoize cache from api-call this allows you to update page content from contentful without restart 

--- a/src/generator/contentful.clj
+++ b/src/generator/contentful.clj
@@ -45,6 +45,8 @@
          (m/decode-response-body)
          (:data))))
 
+
+
 (def ^:private dispatch 
   (memo/memo api-call))
 
@@ -67,7 +69,11 @@
 (comment (get-contentful :asset-query {:$assetId "34YRcoaS4WJ5ORhpMlMHRM"}))
 (comment (get-contentful :entry-query {:entryId "782ka3lNsGXBrnE88Qf3jt"}))
 (comment (get-contentful :card-list-query {:listId "2pJ63nhY2QKbVesxgWOvq9"}))
-(comment (get-contentful :post-collection-query {:type ["news" "dev"]}))
+(comment 
+  
+  (get-contentful :post-collection-query {:type ["news" "dev" "article"]})
+  
+  )
 (comment (json/write-str (:graphql ((get-in query-map [:query :asset-query]) {:assetId "34YRcoaS4WJ5ORhpMlMHRM"}))))
 (comment (:variables (:graphql ((get-in query-map [:query :nav-collection-query]) {:name "Main menu"}))))
 (comment (memo/memo-clear! api-call)) ; evaluate this in REPL to clear memoize cache from api-call this allows you to update page content from contentful without restart 

--- a/src/generator/contentful.clj
+++ b/src/generator/contentful.clj
@@ -77,3 +77,4 @@
 (comment (json/write-str (:graphql ((get-in query-map [:query :asset-query]) {:assetId "34YRcoaS4WJ5ORhpMlMHRM"}))))
 (comment (:variables (:graphql ((get-in query-map [:query :nav-collection-query]) {:name "Main menu"}))))
 (comment (memo/memo-clear! api-call)) ; evaluate this in REPL to clear memoize cache from api-call this allows you to update page content from contentful without restart 
+

--- a/src/generator/contentful.clj
+++ b/src/generator/contentful.clj
@@ -45,8 +45,6 @@
          (m/decode-response-body)
          (:data))))
 
-
-
 (def ^:private dispatch 
   (memo/memo api-call))
 

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -645,17 +645,30 @@ body .content .card-list {
 }
 
 .post-list {
-    @apply grid grid-cols-1  ;
+    @apply grid ;
 
     .post {
-        @apply mb-16 align-text-bottom flex flex-col;
+        @apply mb-16 align-text-bottom grid  gap-4 ;
+        grid-template-columns: 40% 60%;
+        
     
         a.action {
             @apply self-start mt-auto;
         }
-    
+        .image {
+            @apply col-span-1;
+            max-height: 40vh;
+         
+            img {
+                height: 100%;
+                width: 100%;
+                object-fit: cover;
+            }
+        }
+
         .post-body {
             @apply mb-3;
+            
         }
     
         h2 {
@@ -776,5 +789,6 @@ body.post-page {
 
     img {
         @apply my-8;
+        display: none;
     }
 }

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -648,34 +648,28 @@ body .content .card-list {
     @apply grid ;
 
     .post {
-        @apply mb-16  align-text-bottom grid grid-cols-1 md:grid-cols-10 gap-10 ;
-        
-        
-    
+        @apply mb-16  align-text-bottom grid grid-cols-1 md:grid-cols-10 gap-10;
+
         a.action {
             @apply self-start mt-auto float-left md:float-right;
-            
-            align-self:flex-end
         }
+
         .image {
             @apply col-span-4  hidden md:block;
             max-height: 40vh;
-         
-            img {
-                
+            img {    
                 height: 100%;
                 width: 100%;
                 object-fit: cover;
             }
         }
+
         .body {
             @apply col-span-6;
         }
-
+        
         .post-body {
-            @apply mb-3;
-            width: 90%;
-            
+            @apply mb-3;   
         }
     
         h2 {
@@ -793,9 +787,4 @@ body.post-page {
         box-shadow: inset 1px 1px 3px;
         overflow-wrap: break-word;
     } 
-
-    img {
-        @apply my-8;
-        display: none;
-    }
 }

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -645,7 +645,7 @@ body .content .card-list {
 }
 
 .post-list {
-    @apply grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8;
+    @apply grid grid-cols-1  ;
 
     .post {
         @apply mb-16 align-text-bottom flex flex-col;

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -663,6 +663,7 @@ body .content .card-list {
             max-height: 40vh;
          
             img {
+                @apply filter grayscale;
                 height: 100%;
                 width: 100%;
                 object-fit: cover;

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -667,7 +667,7 @@ body .content .card-list {
         .body {
             @apply col-span-6;
         }
-        
+
         .post-body {
             @apply mb-3;   
         }
@@ -780,6 +780,10 @@ body.post-page {
 
     .post-body {
         @apply text-left max-w-screen-md mx-auto;
+    }
+     img {
+        @apply my-8;
+        display: none;
     }
     
     code {

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -781,14 +781,14 @@ body.post-page {
     .post-body {
         @apply text-left max-w-screen-md mx-auto;
     }
-     img {
-        @apply my-8;
+
+    .image {
         display: none;
     }
-    
+
     code {
         @apply my-6 text-base block shadow-white border border-white bg-black p-4 whitespace-pre-wrap;
         box-shadow: inset 1px 1px 3px;
         overflow-wrap: break-word;
-    } 
+    }
 }

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -648,26 +648,28 @@ body .content .card-list {
     @apply grid ;
 
     .post {
-        @apply mb-16 mx-16 align-text-bottom grid  gap-10 ;
-        grid-template-columns: 40% 60%;
-        width: 80vw;
+        @apply mb-16  align-text-bottom grid grid-cols-1 md:grid-cols-10 gap-10 ;
+        
         
     
         a.action {
-            @apply self-start mt-auto;
+            @apply self-start mt-auto float-left md:float-right;
             
             align-self:flex-end
         }
         .image {
-            @apply col-span-1;
+            @apply col-span-4  hidden md:block;
             max-height: 40vh;
          
             img {
-                @apply filter grayscale;
+                
                 height: 100%;
                 width: 100%;
                 object-fit: cover;
             }
+        }
+        .body {
+            @apply col-span-6;
         }
 
         .post-body {

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -648,12 +648,15 @@ body .content .card-list {
     @apply grid ;
 
     .post {
-        @apply mb-16 align-text-bottom grid  gap-4 ;
+        @apply mb-16 mx-16 align-text-bottom grid  gap-10 ;
         grid-template-columns: 40% 60%;
+        width: 80vw;
         
     
         a.action {
             @apply self-start mt-auto;
+            
+            align-self:flex-end
         }
         .image {
             @apply col-span-1;
@@ -668,6 +671,7 @@ body .content .card-list {
 
         .post-body {
             @apply mb-3;
+            width: 90%;
             
         }
     

--- a/src/generator/renderer.clj
+++ b/src/generator/renderer.clj
@@ -235,7 +235,14 @@
   (let [fullbody (empty? (:shortDescription args))
         content (if (empty? (:shortDescription args)) (:content args) (:shortDescription args))]
   [(if fullbody :div.post :li.post)
-   [:h2 (:title args)]
+  ;;Testing out the image rendering in the site 
+  
+   [:div.image
+   
+    (if (:url (:postImage args))
+      [:img {:src (:url (:postImage args))}]
+      nil)]
+   [:div.body [:h2 (:title args)]
    [:div.author
     [:span.name (get-in args [:author :name])]
     [:span.published (renderer.util/iso-to-relative (:publishDate args))]]
@@ -243,22 +250,30 @@
    [:div.post-body (richtext->html (:json content))]
    (if (not fullbody)
      [:a {:class "button action primary" :href (create-url (:slug args))} "Read more"]
-     nil)]))
+     nil)]]))
 
 (defmethod render "PostCollection"
   [args]
   [:div 
-   (into [:ul.post-list] (mapv render (:items args)))])
+   (into [:ul.post-list] (mapv render (:items args ))  )
+   
+   ])
 
 (defmethod render "ArticleList" 
   [args]
   (let [contentful-map (contentful/get-contentful 
-                        :posts-by-list-query {:listId (get-in args [:sys :id]) 
-                                              :limit (:numberOfPostsShown args)})]
+                        :posts-by-list-query {:listId (get-in args [:sys :id ]) 
+                                              :limit (:numberOfPostsShown args)
+                                              
+                                              })]
     [:section.post-list-wrap
      [:div.intro
-       [:h2 (get-in contentful-map [:articleList :websiteTitle])]]
-     (into [:ul.post-list] (mapv render (get-in contentful-map [:articleList :linkedFrom :postCollection :items])))]))
+       [:h2 (get-in contentful-map [:articleList :websiteTitle])] 
+       ] 
+       
+     
+     
+     (into [:ul.post-list] (mapv render (get-in contentful-map [:articleList :linkedFrom :postCollection :items ])))]))
 
 ; Todo implement two person logics: embedded and person page.
 (defmethod render "Person"

--- a/src/generator/renderer.clj
+++ b/src/generator/renderer.clj
@@ -241,7 +241,10 @@
    
     (if (:url (:postImage args))
       [:img {:src (:url (:postImage args))}]
-      nil)]
+      
+      ;;nil
+      [:img {:src "https://img.freepik.com/free-photo/closeup-shot-pine-tree-branch-with-blurred-background_181624-4220.jpg?w=1800&t=st=1691665555~exp=1691666155~hmac=e353d953720b127a7c21680fdbe89c812ff2c0366d3f31bbc003e8cc9fef3809"}]
+      )]
    [:div.body [:h2 (:title args)]
    [:div.author
     [:span.name (get-in args [:author :name])]

--- a/src/generator/renderer.clj
+++ b/src/generator/renderer.clj
@@ -234,26 +234,24 @@
   [args]
   (let [fullbody (empty? (:shortDescription args))
         content (if (empty? (:shortDescription args)) (:content args) (:shortDescription args))]
-  [(if fullbody :div.post :li.post)
-  ;;Testing out the image rendering in the site 
-  
-   [:div.image
-   
-    (if (:url (:postImage args))
-      [:img {:src (:url (:postImage args))}]
-      
-      ;;nil
-      [:img {:src "https://img.freepik.com/free-photo/closeup-shot-pine-tree-branch-with-blurred-background_181624-4220.jpg?w=1800&t=st=1691665555~exp=1691666155~hmac=e353d953720b127a7c21680fdbe89c812ff2c0366d3f31bbc003e8cc9fef3809"}]
-      )]
-   [:div.body [:h2 (:title args)]
-   [:div.author
-    [:span.name (get-in args [:author :name])]
-    [:span.published (renderer.util/iso-to-relative (:publishDate args))]]
-   (into [:div.types] (mapv #(vector :span {:class (str "type " %)} %) (:type args)))
-   [:div.post-body (richtext->html (:json content))]
-   (if (not fullbody)
-     [:a {:class "button action primary" :href (create-url (:slug args))} "Read more"]
-     nil)]]))
+    [(if fullbody :div.post :li.post)
+     [:div.image
+      (if (:url (:postImage args))
+        ;; Alt name not working- doesnt get the info from args
+
+        [:img {:alt (get-in args (:postImage :title)) :src (:url (:postImage args))}]
+
+     
+        [:img {:src "https://img.freepik.com/free-photo/closeup-shot-pine-tree-branch-with-blurred-background_181624-4220.jpg?w=1800&t=st=1691665555~exp=1691666155~hmac=e353d953720b127a7c21680fdbe89c812ff2c0366d3f31bbc003e8cc9fef3809" :alt "pinetree-closeup"}])]
+     [:div.body [:h2 (:title args)]
+      [:div.author
+       [:span.name (get-in args [:author :name])]
+       [:span.published (renderer.util/iso-to-relative (:publishDate args))]]
+      (into [:div.types] (mapv #(vector :span {:class (str "type " %)} %) (:type args)))
+      [:div.post-body (richtext->html (:json content))]
+      (if (not fullbody)
+        [:a {:class "button action primary" :href (create-url (:slug args))} "Read more"]
+        nil)]]))
 
 (defmethod render "PostCollection"
   [args]

--- a/src/generator/renderer.clj
+++ b/src/generator/renderer.clj
@@ -251,26 +251,18 @@
 
 (defmethod render "PostCollection"
   [args]
-  [:div 
-   (into [:ul.post-list] (mapv render (:items args ))  )
-   
-   ])
+  [:div
+   (into [:ul.post-list] (mapv render (:items args)))])
 
-(defmethod render "ArticleList" 
+(defmethod render "ArticleList"
   [args]
-  (let [contentful-map (contentful/get-contentful 
-                        :posts-by-list-query {:listId (get-in args [:sys :id ]) 
-                                              :limit (:numberOfPostsShown args)
-                                              
-                                              })]
+  (let [contentful-map (contentful/get-contentful
+                        :posts-by-list-query {:listId (get-in args [:sys :id])
+                                              :limit (:numberOfPostsShown args)})]
     [:section.post-list-wrap
      [:div.intro
-       [:h2 (get-in contentful-map [:articleList :websiteTitle])] 
-       ] 
-       
-     
-     
-     (into [:ul.post-list] (mapv render (get-in contentful-map [:articleList :linkedFrom :postCollection :items ])))]))
+      [:h2 (get-in contentful-map [:articleList :websiteTitle])]]
+     (into [:ul.post-list] (mapv render (get-in contentful-map [:articleList :linkedFrom :postCollection :items])))]))
 
 ; Todo implement two person logics: embedded and person page.
 (defmethod render "Person"

--- a/src/generator/renderer.clj
+++ b/src/generator/renderer.clj
@@ -237,12 +237,8 @@
     [(if fullbody :div.post :li.post)
      [:div.image
       (if (:url (:postImage args))
-        ;; Alt name not working- doesnt get the info from args
-
-        [:img {:alt (get-in args (:postImage :title)) :src (:url (:postImage args))}]
-
-     
-        [:img {:src "https://img.freepik.com/free-photo/closeup-shot-pine-tree-branch-with-blurred-background_181624-4220.jpg?w=1800&t=st=1691665555~exp=1691666155~hmac=e353d953720b127a7c21680fdbe89c812ff2c0366d3f31bbc003e8cc9fef3809" :alt "pinetree-closeup"}])]
+        [:img {:alt (get-in args [:postImage :title]) :src (:url (:postImage args))}]
+        [:img {:alt "working-hands-and-laptops" :src "https://images.ctfassets.net/038s6vr0kmv0/3shYr3pz9Ldd0w5qzSUYdP/d3f0af0310d1aa71a47e4130ee238040/scott-graham-5fNmWej4tAA-unsplash.jpg?h=250"}])]
      [:div.body [:h2 (:title args)]
       [:div.author
        [:span.name (get-in args [:author :name])]

--- a/src/generator/webserver.clj
+++ b/src/generator/webserver.clj
@@ -67,6 +67,8 @@
     (reset! server nil)
     (println "Web server stopped.")))
 
-(comment (start-webserver))
-(comment (stop-webserver))
-(comment (get-pages))
+(comment
+  (start-webserver)
+  (stop-webserver)
+  (get-pages))
+


### PR DESCRIPTION
Implemented:
     Contentful supports adding small images to blog posts(max 700 x700 px)
     Added default image when no picture is provided when publishing new blog post
     images include relevant alt text in the html
     Stylised article list on cartman.fi, now image next to blog details( pc view and mobile view)

