### PR TITLE
Add title-wrapper class to H2 elements, Centered frontpage title

### DIFF
--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1728,6 +1728,10 @@ body table p {
   }
 }
 
+.front-page .title-wrap{
+  text-align: center;
+}
+
 /** Services page */
 
 .services .content>section:nth-child(odd) {

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -746,6 +746,9 @@ body table {
     div:not(.banner-content-wrap) p {
         @apply 2xl:max-w-screen-xl;
     }
+    .title-wrap{
+        text-align: center;
+    }
 }
 
 

--- a/src/generator/renderer.clj
+++ b/src/generator/renderer.clj
@@ -96,7 +96,7 @@
 
 (defmethod richtext->html "heading-2"
   [m]
-  (into [:h2] (mapv richtext->html (:content m))))
+  [:div.title-wrap (into [:h2] (mapv richtext->html (:content m)))])
 
 (defmethod richtext->html "heading-3"
   [m]


### PR DESCRIPTION
Add class to h2 titles in renderer.cljs and change styles in base.less to center titles in frontpage
