### PR TITLE
Apply narrow style to full width texts

### DIFF
--- a/resources/public/assets/main.css
+++ b/resources/public/assets/main.css
@@ -1720,6 +1720,13 @@ body table p {
  * Page specific styles 
  */
 
+.static-page .content > .doc > p,
+    .static-page .content > .doc > h3 {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 56rem;
+}
+
 /** Front page */
 
 .front-page .title-wrap{

--- a/src/generator/css/base.less
+++ b/src/generator/css/base.less
@@ -740,6 +740,12 @@ body table {
  * Page specific styles 
  */
 
+.static-page .content > .doc {
+    & > p,
+    & > h3 {
+        @apply max-w-4xl mx-auto;
+    }
+}
 
  /** Front page */
 .front-page {


### PR DESCRIPTION

Previously:
<img width="1713" alt="Screenshot 2023-09-01 at 11 12 20" src="https://github.com/Cartman-Digital/www.cartman.fi/assets/5362449/99e93f32-c4da-4532-96a2-cd02aa92f5d7">
<img width="1708" alt="Screenshot 2023-09-01 at 11 12 27" src="https://github.com/Cartman-Digital/www.cartman.fi/assets/5362449/f3eb783f-f037-4529-83a4-b1a4848701ee">

After changes:
<img width="1710" alt="Screenshot 2023-09-01 at 11 12 01" src="https://github.com/Cartman-Digital/www.cartman.fi/assets/5362449/d1258250-cbd9-4ceb-8748-aa40cc953aad">
<img width="1711" alt="Screenshot 2023-09-01 at 11 12 10" src="https://github.com/Cartman-Digital/www.cartman.fi/assets/5362449/a23cb0b4-e6fc-4ac1-8e95-cca48ee69529">